### PR TITLE
coveralls.io now uses a different URL structure

### DIFF
--- a/lib/Dist/Zilla/Plugin/GitHubREADME/Badge.pm
+++ b/lib/Dist/Zilla/Plugin/GitHubREADME/Badge.pm
@@ -69,7 +69,7 @@ sub add_badges {
         if ($badge eq 'travis') {
             push @badges, "[![Build Status](https://travis-ci.org/$user_name/$repository_name.svg?branch=master)](https://travis-ci.org/$user_name/$repository_name)";
         } elsif ($badge eq 'coveralls') {
-            push @badges, "[![Coverage Status](https://coveralls.io/repos/$user_name/$repository_name/badge.svg?branch=master)](https://coveralls.io/r/$user_name/$repository_name?branch=master)"
+            push @badges, "[![Coverage Status](https://coveralls.io/repos/github/$user_name/$repository_name/badge.svg?branch=master)](https://coveralls.io/github/$user_name/$repository_name?branch=master)"
         } elsif ($badge eq 'gitter') {
             push @badges, "[![Gitter chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/$user_name/$repository_name)";
         } elsif ($badge eq 'cpants') {

--- a/t/lib/TestBadges.pm
+++ b/t/lib/TestBadges.pm
@@ -21,7 +21,7 @@ sub badge_patterns {
   my $ur = qr{\Q$user/$repo\E};
   return {
     travis     => qr{//travis-ci.org/$ur\.},
-    coveralls  => qr{//coveralls.io/repos/$ur/badge\.},
+    coveralls  => qr{//coveralls.io/repos/github/$ur/badge\.},
     gitter     => qr{//gitter\.im/$ur\b},
     cpants     => qr{//cpants.cpanauthors.org/dist/\Q$repo\E\.},
     issues     => qr{//img.shields.io/github/issues/$ur\.},


### PR DESCRIPTION
coveralls.io appears to have changed the url structure that maps repos to coverage reports. They added another level between the domain and username, and replaced the /r/ with /github/.

e.g:

```[![Coverage Status](https://coveralls.io/repos/mcmillhj/WUPHF/badge.svg?branch=master)](https://coveralls.io/r/mcmillhj/WUPHF?branch=master)```

versus

```[![Coverage Status](https://coveralls.io/repos/github/mcmillhj/WUPHF/badge.svg?branch=master)](https://coveralls.io/github/mcmillhj/WUPHF?branch=master)```

I noticed this when I made a new Dist::Zilla repo this afternoon and figured I would send in a PR since it was a small change. 