### PR TITLE
Declare minimum Perl version

### DIFF
--- a/META.json
+++ b/META.json
@@ -38,7 +38,8 @@
       "runtime" : {
          "requires" : {
             "Dist::Zilla" : "0",
-            "Path::Tiny" : "0"
+            "Path::Tiny" : "0",
+            "perl" : "5.0014"
          }
       },
       "test" : {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 
-
+use 5.001400;
 
 use ExtUtils::MakeMaker;
 
@@ -14,6 +14,7 @@ my %WriteMakefileArgs = (
   },
   "DISTNAME" => "Dist-Zilla-Plugin-GitHubREADME-Badge",
   "LICENSE" => "perl",
+  "MIN_PERL_VERSION" => "5.001400",
   "NAME" => "Dist::Zilla::Plugin::GitHubREADME::Badge",
   "PREREQ_PM" => {
     "Dist::Zilla" => 0,

--- a/cpanfile
+++ b/cpanfile
@@ -1,3 +1,4 @@
+requires 'perl', '5.0014';
 requires 'Dist::Zilla';
 requires 'Path::Tiny';
 


### PR DESCRIPTION
Although `Perl::MinimumVersion` reports 5.8.5 as the minimum Perl
version, I chose 5.14 here because of 1561d01, which restricted the
Travis tests to this minimum version.

If you want anything changed in the PR, please just let me know and I'll update it and resubmit.