### PR TITLE
Add Test::Pod test dependency

### DIFF
--- a/META.json
+++ b/META.json
@@ -43,7 +43,8 @@
       },
       "test" : {
          "requires" : {
-            "Test::More" : "0.96"
+            "Test::More" : "0.96",
+            "Test::Pod" : "0"
          }
       }
    },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,7 +20,8 @@ my %WriteMakefileArgs = (
     "Path::Tiny" => 0
   },
   "TEST_REQUIRES" => {
-    "Test::More" => "0.96"
+    "Test::More" => "0.96",
+    "Test::Pod" => 0
   },
   "VERSION" => "0.18",
   "test" => {
@@ -32,7 +33,8 @@ my %WriteMakefileArgs = (
 my %FallbackPrereqs = (
   "Dist::Zilla" => 0,
   "Path::Tiny" => 0,
-  "Test::More" => "0.96"
+  "Test::More" => "0.96",
+  "Test::Pod" => 0
 );
 
 

--- a/cpanfile
+++ b/cpanfile
@@ -3,4 +3,5 @@ requires 'Path::Tiny';
 
 on test => sub {
     requires 'Test::More', '0.96';
+    requires 'Test::Pod';
 };


### PR DESCRIPTION
After having built a pristine Perl with perlbrew it turned out that
after having installed all the dependencies via `cpanm --installdeps .`
that the `Test::Pod` module was still required in order to run `dzil
test`.  This patch adds `Test::Pod` to the list of test dependencies so
that this issue doesn't happen to someone else.

If you need this PR changed in any way, please just let me know and I'll update it and resubmit.