### PR TITLE
Add missing prereqs to match use

### DIFF
--- a/META.json
+++ b/META.json
@@ -38,7 +38,10 @@
       "runtime" : {
          "requires" : {
             "Dist::Zilla" : "0",
+            "Moose" : "0",
+            "Moose::Util::TypeConstraints" : "0",
             "Path::Tiny" : "0",
+            "namespace::autoclean" : "0",
             "perl" : "5.0014"
          }
       },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,7 +18,10 @@ my %WriteMakefileArgs = (
   "NAME" => "Dist::Zilla::Plugin::GitHubREADME::Badge",
   "PREREQ_PM" => {
     "Dist::Zilla" => 0,
-    "Path::Tiny" => 0
+    "Moose" => 0,
+    "Moose::Util::TypeConstraints" => 0,
+    "Path::Tiny" => 0,
+    "namespace::autoclean" => 0
   },
   "TEST_REQUIRES" => {
     "Test::More" => "0.96",
@@ -33,9 +36,12 @@ my %WriteMakefileArgs = (
 
 my %FallbackPrereqs = (
   "Dist::Zilla" => 0,
+  "Moose" => 0,
+  "Moose::Util::TypeConstraints" => 0,
   "Path::Tiny" => 0,
   "Test::More" => "0.96",
-  "Test::Pod" => 0
+  "Test::Pod" => 0,
+  "namespace::autoclean" => 0
 );
 
 

--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,9 @@
 requires 'perl', '5.0014';
 requires 'Dist::Zilla';
 requires 'Path::Tiny';
+requires 'Moose';
+requires 'Moose::Util::TypeConstraints';
+requires 'namespace::autoclean';
 
 on test => sub {
     requires 'Test::More', '0.96';


### PR DESCRIPTION
The kwalitee tests on
[CPANTS](http://cpants.cpanauthors.org/dist/Dist-Zilla-Plugin-GitHubREADME-Badge)
show that some modules are used but not declared as prerequisites.  This
change brings code up to date and thus closes the prereq_matches_use
CPANTS core issue for this distribution.