### PR TITLE
Remove Test::More from Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ perl:
     - "5.14"
 before_install:
     - "cpanm Dist::Zilla"
-    - "cpanm Test::More"
     - "cpanm Devel::Cover::Report::Coveralls"
     - "cpanm Devel::Cover::Report::Codecov"
 install:


### PR DESCRIPTION
`Test::More` is in core, so shouldn't need to be explicitly installed as
part of the Travis build.

The Travis tests still pass, however if it was intended to keep `Test::More` here, then please feel free to close the PR unmerged.