### PR TITLE
Add prereq missing from build_requires

### DIFF
--- a/META.json
+++ b/META.json
@@ -48,7 +48,8 @@
       "test" : {
          "requires" : {
             "Test::More" : "0.96",
-            "Test::Pod" : "0"
+            "Test::Pod" : "0",
+            "warnings" : "0"
          }
       }
    },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,7 +25,8 @@ my %WriteMakefileArgs = (
   },
   "TEST_REQUIRES" => {
     "Test::More" => "0.96",
-    "Test::Pod" => 0
+    "Test::Pod" => 0,
+    "warnings" => 0
   },
   "VERSION" => "0.20",
   "test" => {
@@ -41,7 +42,8 @@ my %FallbackPrereqs = (
   "Path::Tiny" => 0,
   "Test::More" => "0.96",
   "Test::Pod" => 0,
-  "namespace::autoclean" => 0
+  "namespace::autoclean" => 0,
+  "warnings" => 0
 );
 
 

--- a/cpanfile
+++ b/cpanfile
@@ -8,4 +8,5 @@ requires 'namespace::autoclean';
 on test => sub {
     requires 'Test::More', '0.96';
     requires 'Test::Pod';
+    requires 'warnings';
 };


### PR DESCRIPTION
The experimental CPANTS metric `build_prereq_matches_use` shows that the
`warnings` prereq is missing from `build_requires`.  By adding this
prereq it is now very explicit what packages are required to build and
test the distribution.