### PR TITLE
Generate "provides" info in META files

### DIFF
--- a/META.json
+++ b/META.json
@@ -38,6 +38,7 @@
       "runtime" : {
          "requires" : {
             "Dist::Zilla" : "0",
+            "Dist::Zilla::Plugin::MetaProvides::Package" : "0",
             "Moose" : "0",
             "Moose::Util::TypeConstraints" : "0",
             "Path::Tiny" : "0",
@@ -50,6 +51,12 @@
             "Test::More" : "0.96",
             "Test::Pod" : "0"
          }
+      }
+   },
+   "provides" : {
+      "Dist::Zilla::Plugin::GitHubREADME::Badge" : {
+         "file" : "lib/Dist/Zilla/Plugin/GitHubREADME/Badge.pm",
+         "version" : "0.20"
       }
    },
    "release_status" : "stable",

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,6 +18,7 @@ my %WriteMakefileArgs = (
   "NAME" => "Dist::Zilla::Plugin::GitHubREADME::Badge",
   "PREREQ_PM" => {
     "Dist::Zilla" => 0,
+    "Dist::Zilla::Plugin::MetaProvides::Package" => 0,
     "Moose" => 0,
     "Moose::Util::TypeConstraints" => 0,
     "Path::Tiny" => 0,
@@ -36,6 +37,7 @@ my %WriteMakefileArgs = (
 
 my %FallbackPrereqs = (
   "Dist::Zilla" => 0,
+  "Dist::Zilla::Plugin::MetaProvides::Package" => 0,
   "Moose" => 0,
   "Moose::Util::TypeConstraints" => 0,
   "Path::Tiny" => 0,

--- a/cpanfile
+++ b/cpanfile
@@ -4,6 +4,7 @@ requires 'Path::Tiny';
 requires 'Moose';
 requires 'Moose::Util::TypeConstraints';
 requires 'namespace::autoclean';
+requires 'Dist::Zilla::Plugin::MetaProvides::Package';
 
 on test => sub {
     requires 'Test::More', '0.96';

--- a/dist.ini
+++ b/dist.ini
@@ -1,6 +1,8 @@
 [@Milla]
 installer = MakeMaker
 
+[MetaProvides::Package]
+
 [GitHubREADME::Badge]
 badges = travis
 badges = coveralls


### PR DESCRIPTION
The experimental CPANTS metric `meta_yml_has_provides` tests if the
`provides` information exists in the META.yml and META.json files.  The
easiest way to implement this is in `Dist::Zilla` projects is to use the
`MetaProvides::Package` plugin, which automatically generates this
information and adds it to the META.* files.  This plugin has been added
to `dist.ini` and as a new dependency to the distribution; the relevant
"provides" metadata has also been added.