### PR TITLE
Add warnings pragma to main package

### DIFF
--- a/lib/Dist/Zilla/Plugin/GitHubREADME/Badge.pm
+++ b/lib/Dist/Zilla/Plugin/GitHubREADME/Badge.pm
@@ -1,6 +1,7 @@
 package Dist::Zilla::Plugin::GitHubREADME::Badge;
 
 use strict;
+use warnings;
 use 5.008_005;
 our $VERSION = '0.20';
 


### PR DESCRIPTION
Perl::Critic (at severity level 4) warns that the `warnings` pragma is
missing from this package.  This change removes the warning.