### PR TITLE
Add shebang line to test scripts

### DIFF
--- a/t/badges.t
+++ b/t/badges.t
@@ -1,3 +1,5 @@
+#!/usr/bin/env perl
+
 use strict;
 use warnings;
 use lib 't/lib';

--- a/t/encoding.t
+++ b/t/encoding.t
@@ -1,3 +1,5 @@
+#!/usr/bin/env perl
+
 use strict;
 use warnings;
 use lib 't/lib';

--- a/t/names.t
+++ b/t/names.t
@@ -1,3 +1,5 @@
+#!/usr/bin/env perl
+
 use strict;
 use warnings;
 use lib 't/lib';

--- a/t/phase.t
+++ b/t/phase.t
@@ -1,3 +1,5 @@
+#!/usr/bin/env perl
+
 use strict;
 use warnings;
 use lib 't/lib';

--- a/t/place.t
+++ b/t/place.t
@@ -1,3 +1,5 @@
+#!/usr/bin/env perl
+
 use strict;
 use warnings;
 use lib 't/lib';


### PR DESCRIPTION
Perl::Critic (at severity level 4) warns that these files don't contain
a `package` declaration.  It is considered by Perl::Critic that any file
that isn't a module is a program, and hence needs a shebang line
pointing to the perl interpreter to denote this.  This change silences
this warning.