### PR TITLE
Make PhaseReadme test package a package

### DIFF
--- a/t/lib/Dist/Zilla/Plugin/PhaseReadme.pm
+++ b/t/lib/Dist/Zilla/Plugin/PhaseReadme.pm
@@ -1,8 +1,8 @@
-use strict;
-use warnings;
-
 package # no_index
   Dist::Zilla::Plugin::PhaseReadme;
+
+use strict;
+use warnings;
 
 use Moose;
 with qw(


### PR DESCRIPTION
... at least as far as Perl::Critic is concerned.  In Perl::Critic at
severity level 4, the `package` declaration isn't found.  The solution
was to move the `strict` and `warnings` pragmas below the `package`
declaration, hence silencing the Perl::Critic warning.  The tests still
pass, so the intended behaviour seems to be the same.