### PR TITLE
Fix docker badges to use lower case

### DIFF
--- a/lib/Dist/Zilla/Plugin/GitHubREADME/Badge.pm
+++ b/lib/Dist/Zilla/Plugin/GitHubREADME/Badge.pm
@@ -117,9 +117,9 @@ sub add_badges {
         } elsif ($badge eq 'gitlab_cover') {
             push @badges, "[![coverage report](https://$base_url/$user_name/$repository_name/badges/master/coverage.svg)]($repository/$user_name/$repository_name/commits/master)";
         } elsif ($badge eq 'docker_automated') {
-            push @badges, "[![Docker Automated Build](https://img.shields.io/docker/automated/$user_name/$repository_name.svg)](https://github.com/$user_name/$repository_name)";
+            push @badges, "[![Docker Automated Build](https://img.shields.io/docker/automated/\L$user_name/$repository_name\E.svg)](https://github.com/\L$user_name/$repository_name\E)";
         } elsif ($badge eq 'docker_build') {
-            push @badges, "[![Docker Build Status](https://img.shields.io/docker/build/$user_name/$repository_name.svg)](https://hub.docker.com/r/$user_name/$repository_name/)";
+            push @badges, "[![Docker Build Status](https://img.shields.io/docker/build/\L$user_name/$repository_name\E.svg)](https://hub.docker.com/r/\L$user_name/$repository_name\E/)";
         }
     }
 

--- a/t/badges.t
+++ b/t/badges.t
@@ -38,6 +38,7 @@ test_badges
       github_tag
       license
       version
+      docker_build
     )],
   },
   'non default badges';

--- a/t/lib/TestBadges.pm
+++ b/t/lib/TestBadges.pm
@@ -31,8 +31,8 @@ sub badge_patterns {
     version      => qr{//img.shields.io/cpan/v/$repo\.},
     gitlab_ci    => qr{//github.com/$ur/badges/master/build.svg},
     gitlab_cover => qr{//github.com/$ur/badges/master/coverage.svg},
-    docker_automated=> qr{//img.shields.io/docker/automated/$ur\.},
-    docker_build    => qr{//img.shields.io/docker/build/$ur\.},
+    docker_automated=> qr{//img.shields.io/docker/automated/\L$ur\E\.},
+    docker_build    => qr{//img.shields.io/docker/build/\L$ur\E\.},
   };
 }
 
@@ -46,8 +46,8 @@ sub build_dist {
   my $test   = {
     content => 'ReadMe, please',
     name    => 'README.mkdn',
-    user    => 'test-author',
-    repo    => 'test-badges',
+    user    => 'Test-Author',
+    repo    => 'Test-Badges',
     %{ shift() || {} },
   };
 


### PR DESCRIPTION
I've noticed an issue with just added docker badges: while repo name on github can use upper case letters (like yours, mine, and I suppose it's usual case for Perl modules on github) related repo on hub.docker.com will be always lower case. Even if I try to create docker repo using upper case it converts it to lower case and url with original upper case name returns 404. Same happens for user name - I've just tried to create account with upper case on docker hub to test this.

Not sure is this issue also affect other badges, so I've fixed only docker's.