### PR TITLE
add github actions badge

### DIFF
--- a/lib/Dist/Zilla/Plugin/GitHubREADME/Badge.pm
+++ b/lib/Dist/Zilla/Plugin/GitHubREADME/Badge.pm
@@ -122,6 +122,8 @@ sub add_badges {
             push @badges, "[![Docker Automated Build](https://img.shields.io/docker/automated/\L$user_name/$repository_name\E.svg)](https://github.com/$user_name/$repository_name)";
         } elsif ($badge eq 'docker_build') {
             push @badges, "[![Docker Build Status](https://img.shields.io/docker/build/\L$user_name/$repository_name\E.svg)](https://hub.docker.com/r/\L$user_name/$repository_name\E/)";
+        } elsif ($badge =~ m{^github_actions/(.+)}) {
+            push @badges, "[![Actions Status](https://github.com/$user_name/$repository_name/workflows/$1/badge.svg)](https://github.com/$user_name/$repository_name/actions)";
         }
     }
 
@@ -174,6 +176,7 @@ Dist::Zilla::Plugin::GitHubREADME::Badge - Dist::Zilla - add badges to github RE
     badges = gitlab_cover
     badges = docker_automated
     badges = docker_build
+    badges = github_actions/test
     place = bottom
     phase = release
 

--- a/t/badges.t
+++ b/t/badges.t
@@ -39,6 +39,7 @@ test_badges
       license
       version
       docker_build
+      github_actions/test
     )],
   },
   'non default badges';

--- a/t/lib/TestBadges.pm
+++ b/t/lib/TestBadges.pm
@@ -33,6 +33,7 @@ sub badge_patterns {
     gitlab_cover => qr{//github.com/$ur/badges/master/coverage.svg},
     docker_automated=> qr{//img.shields.io/docker/automated/\L$ur\E\.},
     docker_build    => qr{//img.shields.io/docker/build/\L$ur\E\.},
+    'github_actions/test' => qr{//github.com/$ur/workflows/test/badge.svg},
   };
 }
 


### PR DESCRIPTION
Fix #38 

See https://help.github.com/en/articles/configuring-a-workflow#adding-a-workflow-status-badge-to-your-repository