### PR TITLE
fix .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 language: perl
-perl:
-    - "5.24"
-    - "5.22"
-    - "5.20"
-    - "5.18"
-    - "5.16"
-    - "5.14"
+matrix:
+    include:
+        - perl: "5.24"
+        - perl: "5.22"
+        - perl: "5.20"
+          dist: trusty
+        - perl: "5.18"
+          dist: trusty
+        - perl: "5.16"
+          dist: trusty
+        - perl: "5.14"
+          dist: trusty
 before_install:
     - "cpanm Dist::Zilla"
     - "cpanm Devel::Cover::Report::Coveralls"


### PR DESCRIPTION
The default ubuntu version in travis ci has changed from trusty (14.04) to xenial (16.04), and xenial does not support old perls.
This PR sets `dist: trusty` explicitly for old perls.

See https://travis-ci.community/t/failure-with-perl-5-16-5-18-5-20/2458