### PR TITLE
Update GitHub actions badge path generation

### DIFF
--- a/lib/Dist/Zilla/Plugin/GitHubREADME/Badge.pm
+++ b/lib/Dist/Zilla/Plugin/GitHubREADME/Badge.pm
@@ -127,7 +127,7 @@ sub add_badges {
         } elsif ($badge eq 'docker_build') {
             push @badges, "[![Docker Build Status](https://img.shields.io/docker/build/\L$user_name/$repository_name\E.svg)](https://hub.docker.com/r/\L$user_name/$repository_name\E/)";
         } elsif ($badge =~ m{^github_actions/(.+)}) {
-            push @badges, "[![Actions Status](https://github.com/$user_name/$repository_name/workflows/$1/badge.svg)](https://github.com/$user_name/$repository_name/actions)";
+            push @badges, "[![Actions Status](https://github.com/$user_name/$repository_name/actions/workflows/$1/badge.svg)](https://github.com/$user_name/$repository_name/actions)";
         } elsif ($badge eq 'cpancover') {
             push @badges, "[![CPAN Cover Status](https://cpancoverbadge.perl-services.de/$distname-$dist_version)](https://cpancoverbadge.perl-services.de/$distname-$dist_version)";
         }
@@ -182,7 +182,7 @@ Dist::Zilla::Plugin::GitHubREADME::Badge - Dist::Zilla - add badges to github RE
     badges = gitlab_cover
     badges = docker_automated
     badges = docker_build
-    badges = github_actions/test
+    badges = github_actions/test.yml
     badges = cpancover
     place = bottom
     phase = release

--- a/t/badges.t
+++ b/t/badges.t
@@ -39,7 +39,7 @@ test_badges
       license
       version
       docker_build
-      github_actions/test
+      github_actions/test.yml
     )],
   },
   'non default badges';


### PR DESCRIPTION
I'm not sure if this has changed recently, but according to https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge a badge should look something like

```md
![example workflow](https://github.com/<OWNER>/<REPOSITORY>/actions/workflows/<WORKFLOW_FILE>/badge.svg)
```

What I'm seeing generated for https://github.com/oalders/App-perlvars is:

```md
[![Actions Status](https://github.com/oalders/App-perlvars/workflows/dzil-build-and-test/badge.svg)](https://github.com/oalders/App-perlvars/actions)
```

[![Actions Status](https://github.com/oalders/App-perlvars/workflows/dzil-build-and-test/badge.svg)](https://github.com/oalders/App-perlvars/actions)

I believe it should actually be:

```md
![Actions Status](https://github.com/oalders/App-perlvars/actions/workflows/dzil-build-and-test.yml/badge.svg)
```

![Actions Status](https://github.com/oalders/App-perlvars/actions/workflows/dzil-build-and-test.yml/badge.svg)
